### PR TITLE
use yarn postinstall instead of yarn init

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,6 @@ This repository is a [monorepo](https://github.com/babel/babel/blob/master/doc/d
 yarn
 ```
 
-#### Initialise after the first install
-
-```sh
-yarn init
-```
-
 #### Run website + Radix
 
 ```sh

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "nohoist": ["**/mdlz-prmtz"]
   },
   "scripts": {
-    "init": "yarn radix-system:build && yarn radix:build",
+    "postinstall": "yarn radix-system:build && yarn radix:build",
     "start": "npm-run-all --parallel radix-system radix radix:storybook website",
     "website": "lerna exec --scope website -- yarn start",
     "website:build": "lerna exec --scope website -- yarn build",


### PR DESCRIPTION
this fix #231 

running `yarn` after cloning the repo, will automatically initialise `radix` and `radix-system`