### PR TITLE
Update Select

### DIFF
--- a/components/Select.tsx
+++ b/components/Select.tsx
@@ -8,7 +8,10 @@ const SelectWrapper = styled('div', {
   borderRadius: '$2',
   boxShadow: 'inset 0 0 0 1px $colors$slate600',
   color: '$hiContrast',
+  fontFamily: '$untitled',
   fontSize: '$1',
+  fontVariantNumeric: 'tabular-nums',
+  fontWeight: 500,
   height: '$5',
 
   '&:focus-within': {
@@ -23,8 +26,7 @@ const StyledSelect = styled('select', {
   border: 'none',
   borderRadius: 'inherit',
   color: 'inherit',
-  fontFamily: 'inherit',
-  fontSize: 'inherit',
+  font: 'inherit',
   outline: 'none',
   width: '100%',
   height: '100%',

--- a/components/Select.tsx
+++ b/components/Select.tsx
@@ -3,41 +3,54 @@ import { styled, CSS } from '../stitches.config';
 import { CaretSortIcon } from '@radix-ui/react-icons';
 import type * as Polymorphic from '@radix-ui/react-polymorphic';
 
-const StyledSelect = styled('select', {
-  appearance: 'none',
+const SelectWrapper = styled('div', {
   backgroundColor: '$loContrast',
-  border: 'none',
-  fontFamily: 'inherit',
-  height: '$5',
-  fontSize: '$1',
-  boxShadow: 'inset 0 0 0 1px $colors$slate600',
-  pl: '$1',
-  pr: '$3',
   borderRadius: '$2',
+  boxShadow: 'inset 0 0 0 1px $colors$slate600',
   color: '$hiContrast',
-  outline: 'none',
+  fontSize: '$1',
+  height: '$5',
 
-  '&:focus': {
+  '&:focus-within': {
+    zIndex: 1,
     boxShadow: 'inset 0px 0px 0px 1px $colors$blue700, 0px 0px 0px 1px $colors$blue700',
   },
 });
 
+const StyledSelect = styled('select', {
+  appearance: 'none',
+  backgroundColor: 'transparent',
+  border: 'none',
+  borderRadius: 'inherit',
+  color: 'inherit',
+  fontFamily: 'inherit',
+  fontSize: 'inherit',
+  outline: 'none',
+  width: '100%',
+  height: '100%',
+  pl: '$1',
+  pr: '$3',
+});
+
 const StyledCaretSortIcon = styled(CaretSortIcon, {
-  color: '$hiContrast',
   position: 'absolute',
-  top: 5,
-  right: 1,
+  pointerEvents: 'none',
+
+  // Use margins instead of top/left to avoid setting "position: relative" on parent,
+  // which would make stacking context tricky with Select used in a control group.
+  marginTop: 5,
+  marginLeft: -16,
 });
 
 type SelectCSSProp = { css?: CSS };
 type SelectOwnProps = SelectCSSProp;
 type SelectComponent = Polymorphic.ForwardRefComponent<'select', SelectOwnProps>;
 
-export const Select = React.forwardRef((props, forwardedRef) => {
+export const Select = React.forwardRef(function Select({ css, ...props }, forwardedRef) {
   return (
-    <div style={{ position: 'relative', zIndex: 0 }}>
+    <SelectWrapper css={css}>
       <StyledSelect ref={forwardedRef} {...props} />
       <StyledCaretSortIcon />
-    </div>
+    </SelectWrapper>
   );
 }) as SelectComponent;


### PR DESCRIPTION
- Update Select styles so that `css` prop goes onto the wrapper rather than actual select
- Remove `position: relative` from wrapper so that select doesn't overlap other controls in a control group