### PR TITLE
Tweaks

### DIFF
--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -145,6 +145,7 @@ const StyledButton = styled(DEFAULT_TAG, {
         },
       },
       ghost: {
+        mixBlendMode: 'multiply',
         backgroundColor: 'transparent',
         fontWeight: 400,
         color: '$hiContrast',

--- a/components/IconButton.tsx
+++ b/components/IconButton.tsx
@@ -75,6 +75,7 @@ const StyledIconButton = styled(DEFAULT_TAG, {
     },
     variant: {
       ghost: {
+        mixBlendMode: 'multiply',
         backgroundColor: 'transparent',
         borderWidth: '0',
         '@hover': {

--- a/components/Input.tsx
+++ b/components/Input.tsx
@@ -71,7 +71,6 @@ const StyledInput = styled(DEFAULT_TAG, {
         height: '$5',
         fontSize: '$1',
         px: '$1',
-        lineHeight: '25px',
         '&:-webkit-autofill::first-line': {
           fontSize: '$1',
         },
@@ -80,7 +79,10 @@ const StyledInput = styled(DEFAULT_TAG, {
         height: '$5',
         fontSize: '$2',
         px: '$1',
-        lineHeight: '25px',
+
+        // Fix potential baseline misalignment when placed on subpixels
+        // (via "vh" margin, in a grid, etc). Affects this size variant only
+        paddingBottom: 1,
         '&:-webkit-autofill::first-line': {
           fontSize: '$2',
         },
@@ -89,7 +91,6 @@ const StyledInput = styled(DEFAULT_TAG, {
         height: '$6',
         fontSize: '$3',
         px: '$2',
-        lineHeight: '35px',
         '&:-webkit-autofill::first-line': {
           fontSize: '$3',
         },

--- a/components/SimpleToggle.tsx
+++ b/components/SimpleToggle.tsx
@@ -37,6 +37,7 @@ const StyledSimpleToggle = styled(ToggleButtonPrimitive.Root, {
   height: '$5',
   width: '$5',
   backgroundColor: 'transparent',
+  mixBlendMode: 'multiply',
   '@hover': {
     '&:hover': {
       backgroundColor: '$slate200',


### PR DESCRIPTION
- Fix Chrome's overly large text selection rectangle in inputs:
  <img width="265" alt="Screenshot 2021-03-25 at 19 46 45" src="https://user-images.githubusercontent.com/8441036/112519481-17001880-8da3-11eb-9b63-eadd62169c52.png">
