### PR TITLE
Update TextField line height

### DIFF
--- a/components/TextField.tsx
+++ b/components/TextField.tsx
@@ -16,7 +16,6 @@ const StyledTextField = styled(DEFAULT_TAG, {
   padding: '0',
   width: '100%',
   WebkitTapHighlightColor: 'rgba(0,0,0,0)',
-  lineHeight: '1',
   '&::before': {
     boxSizing: 'border-box',
   },
@@ -72,6 +71,7 @@ const StyledTextField = styled(DEFAULT_TAG, {
         height: '$5',
         fontSize: '$1',
         px: '$1',
+        lineHeight: '$sizes$5',
         '&:-webkit-autofill::first-line': {
           fontSize: '$1',
         },
@@ -81,6 +81,7 @@ const StyledTextField = styled(DEFAULT_TAG, {
         height: '$6',
         fontSize: '$3',
         px: '$2',
+        lineHeight: '$sizes$6',
         '&:-webkit-autofill::first-line': {
           fontSize: '$3',
         },


### PR DESCRIPTION
- Chrome: fixes baseline position when emoji are used in the TextField
<img src="https://user-images.githubusercontent.com/8441036/122084537-95041680-ce0a-11eb-8522-4dbbf28402d1.png" width="473" />
<img src="https://user-images.githubusercontent.com/8441036/122085438-62a6e900-ce0b-11eb-82c8-657806cf3918.gif" width="315" />

- Chrome: fixes baseline position when TextField is positioned with % or vh margin
<img src="https://user-images.githubusercontent.com/8441036/122085551-81a57b00-ce0b-11eb-942f-141cfa834656.gif" width="443" />

- Safari: fixes 0.5px baseline misalignment, fixes clipped characters
<img width="475" alt="Screenshot 2021-06-15 at 18 58 05" src="https://user-images.githubusercontent.com/8441036/122085703-a568c100-ce0b-11eb-96a9-4362a4a56101.png">

***

Tests for posterity:
https://ys2te.csb.app/
https://codesandbox.io/s/horrible-misalignment-wfhw9?file=/src/App.js