### PR TITLE
fix typo on heading text

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2184,7 +2184,7 @@ function Home() {
             <Flex css={{ gap: '$4', width: '150px', mb: '$7' }}>
               <Slider defaultValue={[25, 75]} />
             </Flex>
-            <Heading css={{ mb: '$6' }}>Vertical orientaiton</Heading>
+            <Heading css={{ mb: '$6' }}>Vertical orientation</Heading>
             <Box css={{ mt: '$6' }}>
               <Slider defaultValue={[50]} orientation="vertical" css={{ height: 75 }} />
             </Box>


### PR DESCRIPTION
This is a simple PR to replace `orientaiton` with `orientation`