### PR TITLE
`export` `AppBar` from `index`

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -5,6 +5,7 @@ export {
   AccordionContent,
 } from './components/Accordion';
 export { Alert } from './components/Alert';
+export { AppBar } from './components/AppBar';
 export {
   AlertDialog,
   AlertDialogAction,


### PR DESCRIPTION
There's a missing `export` for `AppBar`. Can we push a release with the fix?